### PR TITLE
Remove image_optim dependency;

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Code extracted from discourse source (thanks guys!) - I needed this functionalit
 
 System requirements
 
-    sudo apt-get install -y advancecomp gifsicle jhead jpegoptim libjpeg-progs optipng pngcrush pngquant
+    sudo apt-get install -y imagemagick
 
 Add this line to your application's Gemfile:
 

--- a/letter_avatar.gemspec
+++ b/letter_avatar.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = %q{Create nice initals avatars from your users usernames}
   spec.homepage      = "https://github.com/ksz2k/letter_avatar"
   spec.license       = "GPL"
-  
+
   spec.rubyforge_project = "letter_avatar"
 
   spec.files         = `git ls-files`.split($/)
@@ -22,5 +22,4 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "image_optim"
 end

--- a/lib/letter_avatar.rb
+++ b/lib/letter_avatar.rb
@@ -1,5 +1,6 @@
 require "letter_avatar/version"
 require "letter_avatar/avatar"
+require "letter_avatar/avatar_helper"
 
 module LetterAvatar
 
@@ -27,7 +28,6 @@ module LetterAvatar
     `convert #{instructions}`
 
     if $?.exitstatus == 0
-      ImageOptim.new.optimize_image(to) rescue nil
       true
     else
       false

--- a/lib/letter_avatar/avatar.rb
+++ b/lib/letter_avatar/avatar.rb
@@ -73,7 +73,7 @@ module LetterAvatar
           -gravity Center
           -stroke #{to_rgb(stroke)}
           -strokewidth 2
-          -annotate -5+40 '#{letter}'
+          -annotate -5+20 '#{letter}'
           '#{filename}'
         }
 

--- a/lib/letter_avatar/avatar.rb
+++ b/lib/letter_avatar/avatar.rb
@@ -71,16 +71,13 @@ module LetterAvatar
           -pointsize 200
           -fill white
           -gravity Center
-          -font 'Helvetica'
           -stroke #{to_rgb(stroke)}
           -strokewidth 2
-          -annotate -5+25 '#{letter}'
+          -annotate -5+40 '#{letter}'
           '#{filename}'
         }
 
         `convert #{instructions.join(" ")}`
-
-        ImageOptim.new.optimize_image(filename) rescue nil
 
         filename
       end

--- a/lib/letter_avatar/avatar_helper.rb
+++ b/lib/letter_avatar/avatar_helper.rb
@@ -1,16 +1,18 @@
 # encoding: UTF-8
-module LetterAvatar::AvatarHelper
+module LetterAvatar
+  module AvatarHelper
 
-  def letter_avatar_for(name, size = 64)
-    LetterAvatar.generate(name, size)
+    def letter_avatar_for(name, size = 64)
+      LetterAvatar.generate(name, size)
+    end
+
+    def letter_avatar_url_for(avatar_path)
+      avatar_path.to_s.sub('public/','/')
+    end
+
+    def letter_avatar_tag(name, size = 64, options = {})
+      image_tag(letter_avatar_url_for(letter_avatar_for(name, size)), options)
+    end
+
   end
-
-  def letter_avatar_url_for(avatar_path)
-    avatar_path.to_s.gsub(/public/,'')
-  end
-
-  def letter_avatar_tag(name, size = 64, options = {})
-    image_tag(letter_avatar_url_for(letter_avatar_for(name, size)), options)
-  end
-
 end


### PR DESCRIPTION
- Remove image_optim dependency; #1
- Fix text render position in center;
- Remove special font name in convert command, let it use the default font for compatible different OS.

Example:

![240](https://cloud.githubusercontent.com/assets/5518/10778995/39863a5e-7d66-11e5-8e61-40e51b3cc4fd.png) 
![241](https://cloud.githubusercontent.com/assets/5518/10779004/541b98b4-7d66-11e5-8186-96d7bfbb1763.png)
