### PR TITLE
fix a bug of using in sinatra

### DIFF
--- a/lib/letter_avatar/avatar.rb
+++ b/lib/letter_avatar/avatar.rb
@@ -20,7 +20,7 @@ module LetterAvatar
         def self.from_username(username)
           identity = new
           identity.color = LetterAvatar::Colors.for(username)
-          identity.letter = username.first.upcase
+          identity.letter = username[0].upcase
 
           identity
         end


### PR DESCRIPTION
The String#first method was defined in Rails . So when used in other framework, like Sinatra and Padrino, this will be a bug.
