### PR TITLE
extend objects with ActionView::Helpers::AssetTagHelper

### DIFF
--- a/lib/letter_avatar/avatar_helper.rb
+++ b/lib/letter_avatar/avatar_helper.rb
@@ -14,7 +14,7 @@ module LetterAvatar
 
     def letter_avatar_tag(name, size = 64, options = {})
       if defined?(ActionView::Helpers::AssetTagHelper)
-        include ActionView::Helpers::AssetTagHelper
+        extend ActionView::Helpers::AssetTagHelper
         image_tag(letter_avatar_url(name, size), options.merge(alt: name))
       else
         "<img alt=\"#{name}\" class\"#{options.fetch(:class)}\" src=\"#{letter_avatar_url(name, size)}\" />"


### PR DESCRIPTION
`letter_avatar_tag` is returning 

```
undefined method `include' for #<#<Class:0x007fde236474c8>:0x007fde22d54460>`
```

when [including](https://github.com/ksz2k/letter_avatar/blob/master/lib/letter_avatar/avatar_helper.rb#L17) `AssetTagHelper` because it's an instance method 
