### PR TITLE
Fix bug imagemagick-7.0.5-4

### DIFF
--- a/lib/letter_avatar.rb
+++ b/lib/letter_avatar.rb
@@ -25,7 +25,6 @@ module LetterAvatar
         -gravity center
         -thumbnail #{width}x#{height}^
         -extent #{width}x#{height}
-        -interpolate bicubic
         -unsharp 2x0.5+0.7+0
         -quality 98
         #{to}


### PR DESCRIPTION
mac10.12.3
imagemagick-7.0.5-4
ghostscript-9.21
letter_avatar (0.3.2)

Can’t resize .

imagemagick-7.0.5-4 don’t support -interpolate bicubic