### PR TITLE
Users Can Define Custom Palettes

### DIFF
--- a/lib/letter_avatar/colors.rb
+++ b/lib/letter_avatar/colors.rb
@@ -1,6 +1,6 @@
 module LetterAvatar
   module Colors
-    PALETTES = [:google, :iwanthue]
+    PALETTES = [:google, :iwanthue, :custom]
 
     GOOGLE_COLORS = [
       [226, 95, 81], # A

--- a/lib/letter_avatar/colors.rb
+++ b/lib/letter_avatar/colors.rb
@@ -276,7 +276,18 @@ module LetterAvatar
 
 		def self.with_custom(username)
 			custom_palette = LetterAvatar.custom_palette
+			raise "Missing Custom Palette, please set config.custom_palette if using :custom" if custom_palette.nil?
+			raise "Invalid Custom Palette, please update config.custom_palette" unless valid_custom_palette
 			custom_palette[Digest::MD5.hexdigest(username)[0...15].to_i(16) % custom_palette.length]
+		end
+		
+		def self.valid_custom_palette
+			palette = LetterAvatar.custom_palette
+			return false unless palette.is_a?(Array)
+			return palette.all? do |color| 
+				false unless color.is_a?(Array)
+				color.all? {|i| i.is_a?(Integer) }
+			end
 		end
 
     # Colors form Google Inbox

--- a/lib/letter_avatar/colors.rb
+++ b/lib/letter_avatar/colors.rb
@@ -274,6 +274,11 @@ module LetterAvatar
       end
     end
 
+		def self.with_custom(username)
+			custom_palette = LetterAvatar.custom_palette
+			custom_palette[Digest::MD5.hexdigest(username)[0...15].to_i(16) % custom_palette.length]
+		end
+
     # Colors form Google Inbox
     # https://inbox.google.com
     def self.google

--- a/lib/letter_avatar/configuration.rb
+++ b/lib/letter_avatar/configuration.rb
@@ -21,7 +21,7 @@ module LetterAvatar
     end
 
     def colors_palette=(v)
-      @colors_palette = v if v.in?(Colors::PALETTES)
+      @colors_palette = v if Colors::PALETTES.include?(v)
     end
 
     def weight

--- a/lib/letter_avatar/configuration.rb
+++ b/lib/letter_avatar/configuration.rb
@@ -24,6 +24,14 @@ module LetterAvatar
       @colors_palette = v if Colors::PALETTES.include?(v)
     end
 
+		def custom_palette
+			@custom_palette ||= nil
+		end
+
+		def custom_palette=(v)
+			@custom_palette = v
+		end
+
     def weight
       @weight ||= 300
     end


### PR DESCRIPTION
As a designer I want to ensure the colors used by letter_avatar match the color theme of my website.  To do this I need a quick way to define custom palettes for letter_avatar to use.

This PR enables users to define a custom palette in the config block and validates the custom input
```ruby 
CUSTOM_PALETTE = [ [120, 132, 205], [91, 149, 249],[72, 194, 249],[69, 208, 226]]	
LetterAvatar.setup do |config|
  config.fill_color        = 'rgba(255, 255, 255, 1)'         # default is 'rgba(255, 255, 255, 0.65)'
  config.cache_base_path   = 'testy_tars'                    # default is 'public/system'
  config.colors_palette    = :custom	                       # default is :google
  config.weight            = 500                                        # default is 300
  config.annotate_position = '-0+10'                           # default is -0+5
  config.letters_count     = 2                                        # default is 1
  config.pointsize         = 70                                        # default is 140
  config.custom_palette = CUSTOM_PALETTE        # default is nil
end
```

