### PR TITLE
BugFix of model include of ::HasAvatar results in error.

### DIFF
--- a/lib/letter_avatar.rb
+++ b/lib/letter_avatar.rb
@@ -5,6 +5,7 @@ require 'letter_avatar/configuration'
 require 'letter_avatar/avatar'
 require 'letter_avatar/avatar_helper'
 require 'letter_avatar/colors'
+require 'letter_avatar/has_avatar'
 
 module LetterAvatar
   extend LetterAvatar::Configuration


### PR DESCRIPTION
The documentation doesn't work because missing the require line for "HasAvatar" submodule. I tested with this change and it works perfectly now.